### PR TITLE
Fix jaggr exiting on too large input (> 64KiB)

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -64,9 +66,17 @@ func main() {
 		}
 	}()
 
-	s := bufio.NewScanner(os.Stdin)
-	for s.Scan() {
-		jq, err := gojq.NewStringQuery(s.Text())
+	r := bufio.NewReader(os.Stdin)
+	for {
+		line, err := r.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			fatal("reading input: ", err)
+		}
+
+		jq, err := gojq.NewStringQuery(line)
 		if err != nil {
 			fatal("invalid input: ", err)
 		}


### PR DESCRIPTION
jaggr was exiting with code 0 without any output, confusing its users (see issue #1), as it was not handling bufio.Scanner's error correctly.
If the input is too large (> 64 KiB, which occurs frequently with large HTTP responses with vegeta output), bufio.Scanner stops scanning.
According to bufio.Scanner's docs, programs that need more control over large tokens, they should use bufio.Reader.

probably fixes #1 